### PR TITLE
feat(MIG-009): Migrate URL encoding functions to Python

### DIFF
--- a/tests/python/unit/test_http_param_utils.py
+++ b/tests/python/unit/test_http_param_utils.py
@@ -1,25 +1,30 @@
 #!/usr/bin/env python3
 """
-Unit tests for HTTP parameter parsing (MIG-004)
+Unit tests for HTTP parameter parsing (MIG-004, MIG-009)
 
 Test File: UT-PY-015
-Issue: MIG-004 - Migrate HTTP parameter parsing
+Issues:
+  - MIG-004 - Migrate HTTP parameter parsing
+  - MIG-009 - Migrate URL encoding functions
 OCaml Reference: 
+  - source_geneweb/lib/util/mutil.ml:930-979 (encode function)
   - source_geneweb/lib/util/mutil.ml:982-1039 (decode function)
   - source_geneweb/bin/gwd/gwd.ml:174-180 (extract_assoc function)
 
 Purpose:
     Validate the Python implementation of OCaml HTTP parameter parsing functions:
+    - Mutil.encode: URL encoding with percent encoding and space-to-plus
     - Mutil.decode: URL decoding with percent encoding and plus-to-space
     - gwd.extract_assoc: Parameter extraction from key-value list
 
 Coverage:
-    - URL decoding (percent encoding)
-    - Plus to space conversion
+    - URL encoding (percent encoding, space to plus)
+    - URL decoding (percent encoding, plus to space)
     - Special characters
     - UTF-8 encoding
     - Parameter extraction
     - Edge cases (empty, missing, duplicates)
+    - Roundtrip (encode then decode)
 
 Author: Python Migration Team
 Date: 2025-10-29
@@ -34,7 +39,81 @@ test_dir = Path(__file__).parent.parent
 sys.path.insert(0, str(test_dir))
 
 import pytest
-from utils.http_params import url_decode, extract_param, parse_query_string, extract_all_params
+from utils.http_params import url_encode, url_decode, extract_param, parse_query_string, extract_all_params
+
+
+class TestURLEncoding:
+    """Test URL encoding (percent encoding + space to plus)."""
+
+    def test_no_encoding_needed(self):
+        """Simple alphanumeric strings unchanged."""
+        assert url_encode("hello") == "hello"
+        assert url_encode("HelloWorld") == "HelloWorld"
+        assert url_encode("test123") == "test123"
+
+    def test_space_to_plus(self):
+        """Spaces converted to plus signs."""
+        assert url_encode("Hello World") == "Hello+World"
+        assert url_encode("Jean François") == "Jean+Fran%C3%A7ois"
+        assert url_encode("multiple  spaces") == "multiple++spaces"
+
+    def test_special_characters(self):
+        """Special characters percent-encoded."""
+        assert url_encode("O'Brien") == "O%27Brien"
+        assert url_encode("price = $100") == "price+%3D+%24100"
+        assert url_encode("a&b") == "a%26b"
+        assert url_encode("a#b") == "a%23b"
+        assert url_encode("a@b") == "a%40b"
+        assert url_encode("a:b") == "a%3Ab"
+
+    def test_utf8_encoding(self):
+        """UTF-8 characters percent-encoded."""
+        assert url_encode("Jean-François") == "Jean-Fran%C3%A7ois"
+        assert url_encode("é") == "%C3%A9"
+        assert url_encode("à") == "%C3%A0"
+        assert url_encode("Müller") == "M%C3%BCller"
+        assert url_encode("北京") == "%E5%8C%97%E4%BA%AC"
+
+    def test_control_characters(self):
+        """Control characters encoded."""
+        # Newline
+        assert url_encode("line1\nline2") == "line1%0Aline2"
+        # Tab
+        assert url_encode("tab\there") == "tab%09here"
+        # Carriage return
+        assert url_encode("text\r") == "text%0D"
+
+    def test_reserved_characters(self):
+        """Reserved URL characters encoded."""
+        # Query string reserved chars
+        assert url_encode("a?b") == "a%3Fb"  # ?
+        assert url_encode("a/b") == "a%2Fb"  # /
+        assert url_encode("a=b") == "a%3Db"  # =
+        assert url_encode("a&b") == "a%26b"  # &
+        # Path reserved chars
+        assert url_encode("a;b") == "a%3Bb"  # ;
+        # Fragment reserved chars
+        assert url_encode("a#b") == "a%23b"  # #
+
+    def test_empty_string(self):
+        """Empty string returns empty."""
+        assert url_encode("") == ""
+
+    def test_leading_trailing_spaces(self):
+        """Leading/trailing spaces encoded."""
+        assert url_encode("  hello  ") == "++hello++"
+        assert url_encode(" test ") == "+test+"
+
+    def test_multiple_special_chars(self):
+        """Multiple special characters all encoded."""
+        assert url_encode("file://path?query=value#fragment") == "file%3A%2F%2Fpath%3Fquery%3Dvalue%23fragment"
+        assert url_encode("a<b>c\"d'e") == "a%3Cb%3Ec%22d%27e"
+
+    def test_unicode_combinations(self):
+        """Complex Unicode strings encoded."""
+        assert url_encode("Café №1") == "Caf%C3%A9+%E2%84%961"
+        assert url_encode("日本語") == "%E6%97%A5%E6%9C%AC%E8%AA%9E"
+        assert url_encode("Résumé & CV") == "R%C3%A9sum%C3%A9+%26+CV"
 
 
 class TestURLDecoding:
@@ -341,6 +420,66 @@ class TestIntegrationWithOCamlPatterns:
         assert params == []
 
 
+class TestRoundtripEncoding:
+    """Test roundtrip encoding/decoding (encode then decode)."""
+
+    def test_simple_roundtrip(self):
+        """Encode then decode returns original."""
+        original = "Hello World"
+        encoded = url_encode(original)
+        decoded = url_decode(encoded)
+        assert decoded == original
+
+    def test_special_chars_roundtrip(self):
+        """Special characters roundtrip correctly."""
+        test_cases = [
+            "O'Brien",
+            "price = $100",
+            "file#1: name",
+            "a&b=c",
+            "test?query=value"
+        ]
+        for original in test_cases:
+            encoded = url_encode(original)
+            decoded = url_decode(encoded)
+            assert decoded == original, f"Roundtrip failed for: {original}"
+
+    def test_utf8_roundtrip(self):
+        """UTF-8 characters roundtrip correctly."""
+        test_cases = [
+            "Jean-François",
+            "Müller",
+            "北京",
+            "Café №1",
+            "Résumé & CV"
+        ]
+        for original in test_cases:
+            encoded = url_encode(original)
+            decoded = url_decode(encoded)
+            assert decoded == original, f"Roundtrip failed for: {original}"
+
+    def test_empty_string_roundtrip(self):
+        """Empty string roundtrip."""
+        original = ""
+        encoded = url_encode(original)
+        decoded = url_decode(encoded)
+        assert decoded == original
+
+    def test_spaces_roundtrip(self):
+        """Multiple spaces roundtrip correctly."""
+        test_cases = [
+            "  leading",
+            "trailing  ",
+            "  both  ",
+            "multiple  spaces  here"
+        ]
+        for original in test_cases:
+            encoded = url_encode(original)
+            decoded = url_decode(encoded, strip_spaces=False)
+            # Note: decode strips spaces by default, so test with strip_spaces=False
+            assert decoded == original, f"Roundtrip failed for: {original}"
+
+
 class TestRealWorldQueryStrings:
     """Test with real-world GeneWeb query strings."""
 
@@ -364,6 +503,17 @@ class TestRealWorldQueryStrings:
         params = parse_query_string(query)
         result = extract_all_params(params)
         assert result == {'p': 'François', 'n': 'García'}
+
+    def test_encoded_query_construction(self):
+        """Build query string with url_encode."""
+        # Encode parameter values
+        firstname = url_encode("Jean-François")
+        surname = url_encode("O'Brien")
+        query = f"p={firstname}&n={surname}"
+        # Parse and decode
+        params = parse_query_string(query)
+        result = extract_all_params(params)
+        assert result == {'p': 'Jean-François', 'n': "O'Brien"}
 
     def test_complex_query(self):
         """Complex query with multiple parameters."""

--- a/tests/python/utils/__init__.py
+++ b/tests/python/utils/__init__.py
@@ -6,7 +6,7 @@ from .number_formatter import format_number_with_separator, LOCALE_SEPARATORS
 from .name_utils import name_lower, name_strip, strip_lower, contains_only_ascii, is_normalized_name
 from .string_utils import strip_c, purge, contains_forbidden_char, FORBIDDEN_CHAR
 from .roman_numerals import roman_of_arabian, arabian_of_roman
-from .http_params import url_decode, extract_param, parse_query_string, extract_all_params
+from .http_params import url_encode, url_decode, extract_param, parse_query_string, extract_all_params
 from .date_validation import leap_year, nb_days_in_month
 from .date_comparison import (
     Precision, Calendar, Dmy, Dgreg, Dtext, Date,
@@ -27,6 +27,7 @@ __all__ = [
     'FORBIDDEN_CHAR',
     'roman_of_arabian',
     'arabian_of_roman',
+    'url_encode',
     'url_decode',
     'extract_param',
     'parse_query_string',

--- a/tests/python/utils/http_params.py
+++ b/tests/python/utils/http_params.py
@@ -2,17 +2,84 @@
 HTTP parameter parsing utilities - Migration from OCaml GeneWeb.
 
 This module replicates the OCaml HTTP parameter handling functions from GeneWeb,
-specifically migrating Mutil.decode and gwd.extract_assoc.
+specifically migrating Mutil.encode, Mutil.decode, and gwd.extract_assoc.
 
 OCaml Reference:
+- source_geneweb/lib/util/mutil.ml: encode function (lines 930-979)
 - source_geneweb/lib/util/mutil.ml: decode function (lines 982-1039)
 - source_geneweb/bin/gwd/gwd.ml: extract_assoc function (lines 174-180)
 
-Issue: MIG-004 - Migrate HTTP parameter parsing
+Issues:
+- MIG-004 - Migrate HTTP parameter parsing (decode, extract_param)
+- MIG-009 - Migrate URL encoding functions (encode)
 """
 
 from typing import List, Tuple
-from urllib.parse import unquote_plus
+from urllib.parse import unquote_plus, quote_plus
+
+
+def url_encode(s: str) -> str:
+    """
+    Encode string for URL/query string (percent encoding + space to plus).
+    
+    This function replicates the OCaml Mutil.encode behavior:
+    - Spaces are converted to '+'
+    - Special characters are percent-encoded (%XX)
+    - Alphanumeric and safe characters remain unchanged
+    
+    OCaml Reference: source_geneweb/lib/util/mutil.ml:930-979
+    
+    Algorithm (from OCaml):
+    1. Check if encoding is needed (contains spaces or special chars)
+    2. If not needed, return original string
+    3. Otherwise:
+       - Space → '+'
+       - Special chars → '%XX' (hex encoding)
+       - Safe chars → unchanged
+    
+    Special characters that get encoded:
+        Control chars (0x00-0x1F, 0x7F-0xFF)
+        < > " # % { } | \\ ^ ~ [ ] ` ; / ? : @ = & +
+    
+    Args:
+        s: The string to encode
+    
+    Returns:
+        URL-encoded string
+    
+    Examples:
+        >>> url_encode("Hello World")
+        'Hello+World'
+        >>> url_encode("Jean-François")
+        'Jean-Fran%C3%A7ois'
+        >>> url_encode("O'Brien")
+        "O%27Brien"
+        >>> url_encode("price = $100")
+        'price+%3D+%24100'
+        >>> url_encode("normal")
+        'normal'
+        >>> url_encode("")
+        ''
+    
+    Notes:
+        - Python's urllib.parse.quote_plus handles both % and + encoding
+        - The OCaml version manually processes each character
+        - Both produce identical results for most cases
+        - Returns original string if no encoding needed
+    
+    Usage in GeneWeb:
+        - Used to encode parameter values in query strings
+        - Used when building URLs with user input
+        - Used in form data encoding
+    """
+    if not s:
+        return ""
+    
+    # Python's quote_plus does the same as OCaml's encode:
+    # - Encodes spaces as '+'
+    # - Percent-encodes special characters
+    # - Leaves alphanumeric and safe characters unchanged
+    return quote_plus(s, safe='', encoding='utf-8')
 
 
 def url_decode(s: str, strip_spaces: bool = True) -> str:


### PR DESCRIPTION
Implement url_encode function to complement existing url_decode

- Add url_encode: Encode strings for URL/query strings (percent encoding + space to plus)
- Update module docstring to reference MIG-009
- Add comprehensive unit tests for url_encode (10 tests)
- Add roundtrip encoding/decoding tests (5 tests)
- Update existing tests to include url_encode in real-world scenarios
- Export url_encode in utils/__init__.py

OCaml Reference:
- source_geneweb/lib/util/mutil.ml:930-979 (Mutil.encode function)

Key Features:
- Spaces converted to '+'
- Special characters percent-encoded (%XX)
- UTF-8 characters properly encoded
- Control characters encoded
- Reserved URL characters encoded
- Roundtrip compatible with url_decode

Test Coverage:
- 58 total tests passing (10 new encoding + 5 roundtrip + 43 existing)
- All edge cases covered (empty, unicode, special chars, spaces)

Issue: #140