### PR TITLE
feat(MIG-010): Migrate HTML escaping functions to Python

### DIFF
--- a/tests/python/unit/test_html_utils.py
+++ b/tests/python/unit/test_html_utils.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Unit tests for HTML escaping/unescaping (MIG-010)
+"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pytest
+from utils.html_utils import escape_html, unescape_html
+
+
+class TestEscape:
+    def test_basic(self):
+        assert escape_html('<>&') == '&lt;&gt;&amp;'
+        # both quotes escaped (double then single)
+        assert escape_html("\"'\"") == '&quot;&#x27;&quot;'
+
+    def test_text_passthrough(self):
+        assert escape_html('plain text') == 'plain text'
+        assert escape_html('') == ''
+        assert escape_html(None) == ''
+
+    def test_quote_toggle(self):
+        # when quote=False, quotes are not escaped
+        assert escape_html("\"'\"", quote=False) == "\"'\""
+
+    def test_mixed(self):
+        # Genealogy example: Person name with special characters and potential XSS
+        s = "Jean-François & Marie <script>alert('xss')</script>"
+        out = escape_html(s)
+        assert '&lt;script&gt;' in out and '&amp;' in out and '&#x27;' in out
+        assert 'Jean-François' in out  # Name preserved
+    
+    def test_genealogy_names(self):
+        """Test escaping with genealogy-specific names."""
+        # Names with ampersands (e.g., "Smith & Johnson")
+        assert '&amp;' in escape_html("Smith & Johnson Family")
+        # Names with quotes (e.g., "O'Brien", "d'Albert")
+        assert '&#x27;' in escape_html("O'Brien")
+        assert '&quot;' in escape_html('Family "Genealogy" Book')
+    
+    def test_roundtrip_stability(self):
+        # Genealogy data example: Date with HTML-like characters
+        s = 'Born on <14 Nov 1948> in "London"'
+        once = escape_html(s)
+        # Escaping twice would double-escape. Verify escape(unescape(x)) == x
+        assert escape_html(unescape_html(once)) == once
+
+
+class TestUnescape:
+    def test_named_entities(self):
+        assert unescape_html('&lt;&gt;&amp;') == '<>&'
+        assert unescape_html('&quot;&#x27;') == "\"'"
+
+    def test_numeric(self):
+        assert unescape_html('&#60;&#62;') == '<>'
+        assert unescape_html('&#x3C;&#x3E;') == '<>'
+
+    def test_roundtrip(self):
+        # Genealogy example: Person notes with special characters
+        s = 'Résumé & "Genealogical Notes" <birth: 1948>'
+        esc = escape_html(s)
+        assert unescape_html(esc) == s
+
+    def test_empty(self):
+        assert unescape_html('') == ''

--- a/tests/python/utils/__init__.py
+++ b/tests/python/utils/__init__.py
@@ -12,6 +12,7 @@ from .date_comparison import (
     Precision, Calendar, Dmy, Dgreg, Dtext, Date,
     compare_dmy, compare_dmy_opt, compare_date, NotComparable
 )
+from .html_utils import escape_html, unescape_html
 
 __all__ = [
     'format_number_with_separator',
@@ -46,4 +47,7 @@ __all__ = [
     'compare_dmy_opt',
     'compare_date',
     'NotComparable',
+    # HTML utilities
+    'escape_html',
+    'unescape_html',
 ]

--- a/tests/python/utils/html_utils.py
+++ b/tests/python/utils/html_utils.py
@@ -1,0 +1,94 @@
+"""
+HTML escaping/unescaping utilities - Migration from GeneWeb.
+
+This module provides safe HTML entity escaping/encoding and decoding functions
+for use in GeneWeb HTML generation. Essential for preventing XSS attacks and
+ensuring proper display of genealogical data with special characters.
+
+Issue: MIG-010 - Migrate HTML escaping functions
+OCaml Reference: Used throughout GeneWeb when printing HTML output
+
+Usage in GeneWeb:
+- Escaping person names with special characters (e.g., "Smith & Johnson", "O'Brien")
+- Escaping place names with quotes (e.g., "New York, "Queens"")
+- Escaping dates and events in HTML output
+- Preventing XSS attacks from user input
+"""
+
+from html import escape as _py_escape, unescape as _py_unescape
+
+
+def escape_html(text: str, quote: bool = True) -> str:
+    """
+    Escape special characters into HTML-safe sequences.
+    
+    This function is used throughout GeneWeb to safely render genealogical data
+    in HTML pages. It escapes characters that have special meaning in HTML to
+    prevent rendering issues and XSS attacks.
+    
+    Args:
+        text: The string to escape (can be person names, places, dates, notes)
+        quote: If True (default), also escape quotes (' and ")
+    
+    Returns:
+        HTML-escaped string safe for rendering
+    
+    Escaped characters:
+        & → &amp;
+        < → &lt;
+        > → &gt;
+        " → &quot; (if quote=True)
+        ' → &#x27; (if quote=True)
+    
+    Examples:
+        >>> escape_html("Smith & Johnson")
+        'Smith &amp; Johnson'
+        >>> escape_html("O'Brien")
+        "O&#x27;Brien"
+        >>> escape_html('Place: "New York"')
+        'Place: &quot;New York&quot;'
+        >>> escape_html("Jean-François")
+        'Jean-François'  # Unicode preserved
+    
+    Notes:
+        - Unicode characters are preserved (e.g., accents, non-Latin scripts)
+        - Used extensively in GeneWeb HTML generation
+        - Essential for XSS prevention
+    """
+    if text is None:
+        return ''
+    # Python's escape already does the correct transformation
+    return _py_escape(text, quote=quote)
+
+
+def unescape_html(text: str) -> str:
+    """
+    Decode HTML entities back to original text.
+    
+    Converts HTML entities (both named and numeric) back to their original
+    characters. Used when processing HTML-encoded data.
+    
+    Args:
+        text: HTML-encoded string with entities
+    
+    Returns:
+        Decoded string with entities converted to characters
+    
+    Examples:
+        >>> unescape_html('Smith &amp; Johnson')
+        'Smith & Johnson'
+        >>> unescape_html('O&#x27;Brien')
+        "O'Brien"
+        >>> unescape_html('&quot;New York&quot;')
+        '"New York"'
+        >>> unescape_html('&lt;tag&gt;')
+        '<tag>'
+    
+    Notes:
+        - Handles both named entities (&amp;) and numeric (&#x27;)
+        - Essential for roundtrip testing (escape → unescape)
+        - Used when parsing HTML-encoded data
+    """
+    if not text:
+        return ''
+    return _py_unescape(text)


### PR DESCRIPTION
Implement HTML entity escaping/unescaping functions for GeneWeb

- Add escape_html: Escape special characters for safe HTML rendering
- Add unescape_html: Decode HTML entities back to text
- Use Python stdlib html.escape/unescape (matches OCaml behavior)
- Add comprehensive unit tests with genealogy-relevant examples (10 tests)
- Update utils/__init__.py to export new functions

Key Features:
- Escapes & < > to prevent XSS attacks
- Escapes quotes when quote=True (default)
- Preserves Unicode characters (accents, non-Latin scripts)
- Handles both named and numeric entities
- Roundtrip compatible (escape → unescape)

Genealogy Use Cases:
- Escaping person names: "Smith & Johnson", "O'Brien"
- Escaping place names: "New York, \"Queens\""
- Escaping dates and events in HTML output
- Preventing XSS from user input

Test Coverage:
- 10 tests passing
- Genealogy-specific examples (names, places, dates)
- Roundtrip testing
- Edge cases (empty, None, special chars)

Issue: #141